### PR TITLE
Reference support in with_runtime() machinery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ macro_rules! export_runtime {
         pub use $crate::GetEventId;
         pub use $crate::sleep;
 
-        pub fn with_runtime<ReactorFn, FuncT, InitT, ResT: 'static>(
+        pub fn with_runtime<ReactorFn, FuncT, InitT, ResT>(
             reactor_constructor: ReactorFn,
             async_function: FuncT,
             init: InitT,
@@ -41,7 +41,5 @@ macro_rules! export_runtime {
         {
             $crate::with_runtime_base(reactor_constructor(), async_function, init)
         }
-
-
     };
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -58,7 +58,7 @@ where
         }
     }
 
-    pub(crate) fn block_on<'runtime, ResT: 'static, FutureT: 'runtime>(
+    pub(crate) fn block_on<'runtime, ResT: 'runtime, FutureT: 'runtime>(
         &'runtime self,
         future: FutureT,
     ) -> ResT

--- a/src/toy_rt/mod.rs
+++ b/src/toy_rt/mod.rs
@@ -11,7 +11,7 @@ pub use toy_reactor::SleepMode;
 // Make a toy runtime
 crate::export_runtime!(ToyReactor);
 
-pub fn with_runtime_in_mode<FuncT, InitT, ResT: 'static>(
+pub fn with_runtime_in_mode<FuncT, InitT, ResT>(
     sleep_mode: SleepMode,
     async_function: FuncT,
     init: InitT,
@@ -23,5 +23,4 @@ where
     with_runtime(move || ToyReactor::new_with_mode(sleep_mode), 
         async_function, init)
 }
-
 

--- a/src/with_runtime.rs
+++ b/src/with_runtime.rs
@@ -1,28 +1,35 @@
 //    ^
 //  }/_\{   (c) 2020-present Vladimir Zvezda
-//  |\ /|      
+//  |\ /|
 //    v
 use std::future::Future;
 
-use crate::Runtime;
 use crate::Reactor;
+use crate::Runtime;
+
+// [1] - improvement to this machinery to support reference in input and return type
+//       of async function supplied to with_runtime() function. So with this improvement
+//       it is now possible to use with with_runtime like this:
+//
+//       async fn my_main<'b>(rt: &Runtime, init: &'b u32) -> &'b u32 { todo!() }
 
 // A helper trait to solve the lifetime problem for with_runtime().
 // See https://stackoverflow.com/questions/63517250/specify-rust-closures-lifetime
-pub trait LifetimeLinkerFn<'runtime, ReactorT, InitT, ResT: 'static> {
-    type OutputFuture: Future<Output = ResT> + 'runtime;
+pub trait LifetimeLinkerFn<'runtime, ReactorT, InitT, ResT> {
+    type OutputFuture: Future<Output = ResT>; // +'runtime; commented because [1]
 
     fn call(self, arg: &'runtime Runtime<ReactorT>, init: InitT) -> Self::OutputFuture;
 }
 
 // for all F:FnOnce(&'runtime Runtime)->impl Future<Output=ResT> + a define the
 // LifetimeLinkerFn.
-impl<'runtime, ReactorT, InitT, ResT: 'static, FutureT: 'runtime, FuncT> 
-LifetimeLinkerFn<'runtime, ReactorT, InitT, ResT> for FuncT
+impl<'runtime, ReactorT, InitT, ResT, FutureT, FuncT>
+    LifetimeLinkerFn<'runtime, ReactorT, InitT, ResT> for FuncT
 where
     FuncT: FnOnce(&'runtime Runtime<ReactorT>, InitT) -> FutureT,
-    FutureT: Future<Output = ResT> + 'runtime,
-    ReactorT: Reactor + 'runtime,
+    FutureT: Future<Output = ResT>,
+    //    FutureT: 'runtime, // +'runtime, commented because [1]
+    ReactorT: Reactor + 'runtime, // +'runtime is required (won't compile)
 {
     type OutputFuture = FutureT;
 
@@ -33,7 +40,7 @@ where
 
 // This is how you start a async function with aiur. The idea that reactor crate wrap this method
 // into another one.
-pub fn with_runtime_base<ReactorT, FuncT, InitT, ResT: 'static>(
+pub fn with_runtime_base<ReactorT, FuncT, InitT, ResT>(
     reactor: ReactorT,
     async_function: FuncT,
     init: InitT,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,17 +7,67 @@ use std::time::Duration;
 // Use the toy runtime
 use aiur::toy_rt::{self};
 
+// With emulated sleep test run instantly, actual sleep actually wait for specified 
+// amount of time.
+
 //const SLEEP_MODE: toy_rt::SleepMode = toy_rt::SleepMode::Actual;
 const SLEEP_MODE: toy_rt::SleepMode = toy_rt::SleepMode::Emulated;
 
 // Just makes sure that with_runtime() somehow works
 #[test]
 fn toy_runtime_fn_works() {
-    async fn async_42(rt: &toy_rt::Runtime, _: ()) -> u32 {
+    async fn async_42(_rt: &toy_rt::Runtime, _: ()) -> u32 {
         42
     }
 
     assert_eq!(toy_rt::with_runtime_in_mode(SLEEP_MODE, async_42, ()), 42);
+}
+
+// Verifies that with_runtime() works when InitT is a reference
+#[test]
+fn toy_runtime_reference_compiles() {
+    let mut param : u32 = 0;
+
+    async fn async_42ref(_rt: &toy_rt::Runtime, pref: &mut u32) {
+        *pref = 42;
+    }
+
+    // First version of with_runtime() machinery did not work with parameter references,
+    // so this test was introduced. No with with_runtime() works more less as expected.
+    toy_rt::with_runtime_in_mode(SLEEP_MODE, async_42ref, &mut param);
+    assert_eq!(param, 42);
+}
+
+// Verifies that with_runtime() works when InitT is a reference and RetT is a reference as well
+#[test]
+fn toy_runtime_reference_in_return_type_compiles() {
+    let param = (40u32, 2u8);
+
+    // async function takes a param a reference and return a reference as well
+    async fn async_ref_returned<'i>(_rt: &toy_rt::Runtime, pref: &'i (u32, u8)) -> &'i u8 {
+        &(*pref).1
+    }
+    let ret = toy_rt::with_runtime_in_mode(SLEEP_MODE, async_ref_returned, &param);
+    assert_eq!(*ret, 2);
+}
+
+// Verifies that with_runtime() works with mutable references
+#[test]
+fn toy_runtime_mutable_references_in_param_return() {
+    let mut param = (0u32, 0u8);
+
+    // async function takes a param a reference and return a reference as well
+    async fn async_ref_returned<'i>(_rt: &toy_rt::Runtime, pref: &'i mut (u32, u8)) -> &'i mut u8 {
+        (*pref).0 = 42;
+        (*pref).1 = 42;
+
+        &mut (*pref).1
+    }
+    let ret = toy_rt::with_runtime_in_mode(SLEEP_MODE, async_ref_returned, &mut param);
+    assert_eq!(*ret, 42);
+    assert_eq!(param.0, 42);
+    assert_eq!(param.1, 42);
+    //assert_eq!(*ret, 42); // - does not compile, immutable borrow above
 }
 
 async fn async_sleep_once(rt: &toy_rt::Runtime, seconds: u32) {


### PR DESCRIPTION
Code does not compile when async function has non-static references in
InitT or ResT. This commit solves this problem.

See https://github.com/vzvezda/aiur/issues/1